### PR TITLE
Bump cookiecutter template to 773777

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "061bc1d37c9738740fc572861d2fcc54eed352b3",
+  "commit": "7737771881fde49031d915e2a18507981c100ee5",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/773777
