### PR TITLE
feature mx-1888 adds infobox to the ingest page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- infobox to ingest page for "ldap" and "wikidata"
+- new type for aux_provider instead of str
 
 ### Changes
+- type of aux provider from `str` to `AuxProvider`
 
 ### Deprecated
 

--- a/mex/editor/ingest/main.py
+++ b/mex/editor/ingest/main.py
@@ -3,7 +3,11 @@ from typing import cast
 import reflex as rx
 
 from mex.editor.components import render_value
-from mex.editor.ingest.models import IngestResult
+from mex.editor.ingest.models import (
+    AUX_PROVIDER_LDAP,
+    AUX_PROVIDER_WIKIDATA,
+    IngestResult,
+)
 from mex.editor.ingest.state import IngestState
 from mex.editor.layout import page
 
@@ -137,7 +141,18 @@ def search_input() -> rx.Component:
                     autofocus=True,
                     max_length=100,
                     name="query_string",
-                    placeholder="Search here...",
+                    placeholder=rx.match(
+                        IngestState.current_aux_provider,
+                        (
+                            AUX_PROVIDER_LDAP,
+                            'Please use "*" as placeholder e.g. "Muster*".',
+                        ),
+                        (
+                            AUX_PROVIDER_WIKIDATA,
+                            'Please paste "Concept URI" e.g. "http://www.wikidata.org/entity/Q918501"',
+                        ),
+                        "Search here...",
+                    ),
                     style={
                         "--text-field-selection-color": "",
                         "--text-field-focus-color": "transparent",
@@ -206,6 +221,25 @@ def search_results() -> rx.Component:
             pagination(),
             custom_attrs={"data-testid": "search-results-section"},
             style={"width": "100%"},
+        ),
+    )
+
+
+def search_infobox() -> rx.Component:
+    """Render some informations about the specific search provider query format."""
+    return rx.match(
+        IngestState.current_aux_provider,
+        (
+            AUX_PROVIDER_LDAP,
+            rx.callout(
+                'Search users by their fullname. Please use "*" as placeholder e.g. "Muster*".'  # noqa: E501
+            ),
+        ),
+        (
+            AUX_PROVIDER_WIKIDATA,
+            rx.callout(
+                'Search Wikidata by "Concept URI". Please paste URI e.g. "http://www.wikidata.org/entity/Q918501".'
+            ),
         ),
     )
 
@@ -281,6 +315,7 @@ def tab_content() -> rx.Component:
         lambda provider: rx.tabs.content(
             rx.vstack(
                 search_input(),
+                search_infobox(),
                 search_results(),
                 justify="center",
                 align="center",

--- a/mex/editor/ingest/main.py
+++ b/mex/editor/ingest/main.py
@@ -3,11 +3,7 @@ from typing import cast
 import reflex as rx
 
 from mex.editor.components import render_value
-from mex.editor.ingest.models import (
-    AUX_PROVIDER_LDAP,
-    AUX_PROVIDER_WIKIDATA,
-    IngestResult,
-)
+from mex.editor.ingest.models import AuxProvider, IngestResult
 from mex.editor.ingest.state import IngestState
 from mex.editor.layout import page
 
@@ -141,18 +137,7 @@ def search_input() -> rx.Component:
                     autofocus=True,
                     max_length=100,
                     name="query_string",
-                    placeholder=rx.match(
-                        IngestState.current_aux_provider,
-                        (
-                            AUX_PROVIDER_LDAP,
-                            'Please use "*" as placeholder e.g. "Muster*".',
-                        ),
-                        (
-                            AUX_PROVIDER_WIKIDATA,
-                            'Please paste "Concept URI" e.g. "http://www.wikidata.org/entity/Q918501"',
-                        ),
-                        "Search here...",
-                    ),
+                    placeholder="Search here...",
                     style={
                         "--text-field-selection-color": "",
                         "--text-field-focus-color": "transparent",
@@ -230,13 +215,14 @@ def search_infobox() -> rx.Component:
     return rx.match(
         IngestState.current_aux_provider,
         (
-            AUX_PROVIDER_LDAP,
+            AuxProvider.LDAP,
             rx.callout(
-                'Search users by their fullname. Please use "*" as placeholder e.g. "Muster*".'  # noqa: E501
+                "Search users by their fullname. "
+                'Please use "*" as placeholder e.g. "Muster*".',
             ),
         ),
         (
-            AUX_PROVIDER_WIKIDATA,
+            AuxProvider.WIKIDATA,
             rx.callout(
                 'Search Wikidata by "Concept URI". Please paste URI e.g. "http://www.wikidata.org/entity/Q918501".'
             ),

--- a/mex/editor/ingest/models.py
+++ b/mex/editor/ingest/models.py
@@ -1,6 +1,20 @@
+from typing import Final, Literal
+
 import reflex as rx
 
 from mex.editor.models import EditorValue
+
+AuxProvider = Literal["ldap", "orcid", "wikidata"]
+
+AUX_PROVIDER_LDAP: Final = "ldap"
+AUX_PROVIDER_ORDIC: Final = "orcid"
+AUX_PROVIDER_WIKIDATA: Final = "wikidata"
+
+AUX_PROVIDERS: list[AuxProvider] = [
+    AUX_PROVIDER_LDAP,
+    AUX_PROVIDER_ORDIC,
+    AUX_PROVIDER_WIKIDATA,
+]
 
 
 class IngestResult(rx.Base):

--- a/mex/editor/ingest/models.py
+++ b/mex/editor/ingest/models.py
@@ -1,19 +1,22 @@
-from typing import Final, Literal
+from enum import StrEnum
 
 import reflex as rx
 
 from mex.editor.models import EditorValue
 
-AuxProvider = Literal["ldap", "orcid", "wikidata"]
 
-AUX_PROVIDER_LDAP: Final = "ldap"
-AUX_PROVIDER_ORDIC: Final = "orcid"
-AUX_PROVIDER_WIKIDATA: Final = "wikidata"
+class AuxProvider(StrEnum):
+    """Allowed auxiliary providers."""
 
-AUX_PROVIDERS: list[AuxProvider] = [
-    AUX_PROVIDER_LDAP,
-    AUX_PROVIDER_ORDIC,
-    AUX_PROVIDER_WIKIDATA,
+    LDAP = "ldap"
+    ORCID = "orcid"
+    WIKIDATA = "wikidata"
+
+
+ALL_AUX_PROVIDERS: list[AuxProvider] = [
+    AuxProvider.LDAP,
+    AuxProvider.ORCID,
+    AuxProvider.WIKIDATA,
 ]
 
 

--- a/mex/editor/ingest/state.py
+++ b/mex/editor/ingest/state.py
@@ -11,7 +11,12 @@ from requests import HTTPError
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import AnyExtractedModel, PaginatedItemsContainer
 from mex.editor.exceptions import escalate_error
-from mex.editor.ingest.models import IngestResult
+from mex.editor.ingest.models import (
+    AUX_PROVIDER_LDAP,
+    AUX_PROVIDERS,
+    AuxProvider,
+    IngestResult,
+)
 from mex.editor.ingest.transform import transform_models_to_results
 from mex.editor.state import State
 from mex.editor.utils import resolve_editor_value
@@ -26,8 +31,8 @@ class IngestState(State):
     query_string: Annotated[str, Field(max_length=1000)] = ""
     current_page: Annotated[int, Field(ge=1)] = 1
     limit: Annotated[int, Field(ge=1, le=100)] = 50
-    current_aux_provider: str = "ldap"
-    aux_providers: list[str] = ["ldap", "orcid", "wikidata"]
+    current_aux_provider: AuxProvider = AUX_PROVIDER_LDAP
+    aux_providers: list[AuxProvider] = AUX_PROVIDERS
     is_loading: bool = True
 
     @rx.var(cache=False)
@@ -59,7 +64,7 @@ class IngestState(State):
         ].show_properties
 
     @rx.event
-    def set_current_aux_provider(self, value: str) -> None:
+    def set_current_aux_provider(self, value: AuxProvider) -> None:
         """Change the current aux provider."""
         self.current_aux_provider = value
 

--- a/mex/editor/ingest/state.py
+++ b/mex/editor/ingest/state.py
@@ -12,8 +12,7 @@ from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import AnyExtractedModel, PaginatedItemsContainer
 from mex.editor.exceptions import escalate_error
 from mex.editor.ingest.models import (
-    AUX_PROVIDER_LDAP,
-    AUX_PROVIDERS,
+    ALL_AUX_PROVIDERS,
     AuxProvider,
     IngestResult,
 )
@@ -31,8 +30,8 @@ class IngestState(State):
     query_string: Annotated[str, Field(max_length=1000)] = ""
     current_page: Annotated[int, Field(ge=1)] = 1
     limit: Annotated[int, Field(ge=1, le=100)] = 50
-    current_aux_provider: AuxProvider = AUX_PROVIDER_LDAP
-    aux_providers: list[AuxProvider] = AUX_PROVIDERS
+    current_aux_provider: AuxProvider = AuxProvider.LDAP
+    aux_providers: list[AuxProvider] = ALL_AUX_PROVIDERS
     is_loading: bool = True
 
     @rx.var(cache=False)


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->
Added a type for the different aux values. Maybe its a bit overengineered but now u cant say sth like 'set_current_aux_provider("best_aux_ever")'. Would be lovely if we can achieve that the string "ldap", "orcid", "wikidata" are only written once (DRY). Only found a solution with an enum, which i didn't like.

### Added
<!-- New features and interfaces -->
- infobox to ingest page for "ldap" and "wikidata"
- new type for aux_provider instead of str

### Changes
<!-- Changes in existing functionality -->
- type of aux provider from `str` to `AuxProvider`