### PR TITLE
feature/mx-1978 Unsaved changes warning when close browser-tab or -window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Warning when the create or edit browser window/tab is closed or navigated away
 
 ### Changes
 

--- a/assets/page-leave-warn-unsaved-changes.js
+++ b/assets/page-leave-warn-unsaved-changes.js
@@ -1,0 +1,22 @@
+window.mexEditor = {
+    changes: false
+}
+
+window.onbeforeunload = function () {
+    if (window.mexEditor.changes) {
+        return 'Are you sure you want to leave? Unsaved changes will be lost.';
+    }
+};
+if (typeof window !== "undefined" && window.next) {
+    window.next.router.beforePopState(({ url, as, options }) => {
+        result = window.mexEditor.changes ? confirm("Are you sure you want to leave? Unsaved changes will be lost.") : true;
+        if (result) {
+            window.mexEditor.changes = false;
+        }
+        return result;
+    });
+}
+
+window.updateMexEditorChanges = function (value) {
+    window.mexEditor.changes = value;
+}

--- a/mex/editor/create/main.py
+++ b/mex/editor/create/main.py
@@ -5,6 +5,7 @@ from mex.editor.layout import page
 from mex.editor.rules.main import (
     editor_primary_source_stack,
     field_name,
+    page_leave_js,
     rule_page_header,
     validation_errors,
 )
@@ -72,6 +73,7 @@ def index() -> rx.Component:
                 editor_field,
             ),
             validation_errors(),
+            page_leave_js(),
             style={
                 "width": "100%",
                 "marginTop": "calc(2 * var(--space-6))",

--- a/mex/editor/edit/main.py
+++ b/mex/editor/edit/main.py
@@ -3,7 +3,12 @@ import reflex as rx
 from mex.editor.components import render_value
 from mex.editor.edit.state import EditState
 from mex.editor.layout import page
-from mex.editor.rules.main import editor_field, rule_page_header, validation_errors
+from mex.editor.rules.main import (
+    editor_field,
+    page_leave_js,
+    rule_page_header,
+    validation_errors,
+)
 from mex.editor.rules.state import RuleState
 
 
@@ -34,6 +39,7 @@ def index() -> rx.Component:
                 editor_field,
             ),
             validation_errors(),
+            page_leave_js(),
             style={
                 "width": "100%",
                 "marginTop": "calc(2 * var(--space-6))",

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -567,3 +567,13 @@ def rule_page_header(title: rx.Component) -> rx.Component:
             "zIndex": "999",
         },
     )
+
+
+def page_leave_js() -> rx.Component:
+    """Render page leave java script import.
+
+    Returns:
+        rx.Component: The script component refrencing the
+        '/page-leave-warn-unsaved-changes.js'
+    """
+    return rx.script(src="/page-leave-warn-unsaved-changes.js")

--- a/mex/editor/rules/state.py
+++ b/mex/editor/rules/state.py
@@ -36,6 +36,7 @@ class RuleState(State):
     fields: list[EditorField] = []
     stem_type: str | None = None
     validation_messages: list[ValidationMessage] = []
+    has_changes: bool = False
 
     @rx.event(background=True)
     async def resolve_identifiers(self) -> None:
@@ -142,6 +143,8 @@ class RuleState(State):
                 "backend", "error submitting rule set", exc.response.text
             )
             return
+
+        yield self.set_has_changes(False)
         # clear cache to show edits in the UI
         resolve_identifier.cache_clear()
         # trigger redirect to edit page or refresh state
@@ -225,40 +228,64 @@ class RuleState(State):
             index
         ].being_edited = not primary_source.editor_values[index].being_edited
 
+    def update_has_changes(self) -> EventSpec:
+        """Update the has changes value on client side."""
+        return rx.call_script(
+            f"window.updateMexEditorChanges({str(self.has_changes).lower()})",
+        )
+
     @rx.event
-    def add_additive_value(self, field_name: str) -> None:
+    def set_has_changes(self, value: bool) -> EventSpec:  # noqa: FBT001
+        """Set the has changes attribute to the given value.
+
+        Args:
+            value (bool): The value of the has changes attribute.
+        """
+        self.has_changes = value
+        return self.update_has_changes()
+
+    @rx.event
+    def add_additive_value(self, field_name: str) -> EventSpec:
         """Add an additive rule to the given field."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values.append(EditorValue(being_edited=True))
+        return self.set_has_changes(True)
 
     @rx.event
-    def remove_additive_value(self, field_name: str, index: int) -> None:
+    def remove_additive_value(self, field_name: str, index: int) -> EventSpec:
         """Remove an additive rule from the given field."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values.pop(index)
+        return self.set_has_changes(True)
 
     @rx.event
-    def set_text_value(self, field_name: str, index: int, value: str) -> None:
+    def set_text_value(self, field_name: str, index: int, value: str) -> EventSpec:
         """Set the text attribute on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].text = value
+        return self.set_has_changes(True)
 
     @rx.event
-    def set_identifier_value(self, field_name: str, index: int, value: str) -> None:
+    def set_identifier_value(
+        self, field_name: str, index: int, value: str
+    ) -> EventSpec:
         """Set the identifier attribute on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].identifier = value
         primary_source.editor_values[index].href = f"/item/{value}"
+        return self.set_has_changes(True)
 
     @rx.event
-    def set_badge_value(self, field_name: str, index: int, value: str) -> None:
+    def set_badge_value(self, field_name: str, index: int, value: str) -> EventSpec:
         """Set the badge attribute on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].badge = value
+        return self.set_has_changes(True)
 
     @rx.event
-    def set_href_value(self, field_name: str, index: int, value: str) -> None:
+    def set_href_value(self, field_name: str, index: int, value: str) -> EventSpec:
         """Set an external href on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].href = value
         primary_source.editor_values[index].external = True
+        return self.set_has_changes(True)

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -573,7 +573,10 @@ def test_edit_page_warn_tab_close(edit_page: Page) -> None:
 
     # back to edit site
     page.go_back()
-    page.wait_for_url("**/item/**", wait_until="domcontentloaded")
+    page.wait_for_url("**/item/**")
+    page.wait_for_selector(
+        "[data-testid='new-additive-alternativeTitle-00000000000000']"
+    )
     page.screenshot(
         path="tests_edit_test_main-test_edit_page_warn_tab_close-back_on_edit.png"
     )

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -1,7 +1,7 @@
 import re
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Dialog, Page, expect
 
 from mex.common.fields import MERGEABLE_FIELDS_BY_CLASS_NAME
 from mex.common.models import (
@@ -558,3 +558,61 @@ def test_required_fields_red_asterisk(
             expect(asterisk).to_have_css("color", "rgb(255, 0, 0)")
         else:
             expect(asterisk).to_have_count(0)
+
+
+@pytest.mark.integration
+def test_edit_page_warn_tab_close(edit_page: Page) -> None:
+    page = edit_page
+
+    # ensure navigation without changes is working
+    page.goto("https://www.rki.de")
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_warn_tab_close-rki_website.png"
+    )
+    assert "https://www.rki.de" in page.url
+
+    # back to edit site
+    page.go_back()
+    page.wait_for_url("**/item/**", wait_until="domcontentloaded")
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_warn_tab_close-back_on_edit.png"
+    )
+
+    # change a value
+    page.get_by_test_id("new-additive-alternativeTitle-00000000000000").click()
+    page.get_by_test_id("additive-rule-alternativeTitle-0-text").fill(
+        "new alternative title"
+    )
+
+    handle_dialog_called: list[bool] = []
+
+    def _handle_dialog(dialog: Dialog) -> None:
+        # damn i love python
+        nonlocal handle_dialog_called
+
+        assert dialog.type == "beforeunload"
+        handle_dialog_called.append(True)
+        # stay on the side
+        dialog.dismiss()
+
+    page.on("dialog", _handle_dialog)
+
+    # won't work cuz we dismiss the dialog
+    with pytest.raises(Exception, match="Timeout"):
+        page.goto("https://www.rki.de", timeout=3000)
+
+    # ensure still on edit site and dialog was called
+    assert "/item/" in page.url
+    assert len(handle_dialog_called) == 1
+    assert handle_dialog_called[0]
+
+    # after save we should navigate again without dialog
+    page.get_by_test_id("submit-button").click()
+    page.wait_for_selector(".editor-toast")
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_warn_tab_close-save_toast.png"
+    )
+
+    page.goto("https://www.rki.de")
+    assert "https://www.rki.de" in page.url
+    assert len(handle_dialog_called) == 1


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->

### Added
<!-- New features and interfaces -->
- Warning when the create or edit browser window/tab is closed or navigated away

### Changes
<!-- Changes in existing functionality -->

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
