### PR TITLE
feature/mx-1979 unsaved changes between reflex pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Warning when a page reflex navigates and there are still changes on the current page
 - added a switch to toggle all primary sources and values in the edit page
 - added textareas for fields listed in mex/editor/models.yaml
 - Warning when the create or edit browser window/tab is closed or navigated away

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -3,6 +3,7 @@ import reflex as rx
 from mex.editor.ingest.state import IngestState
 from mex.editor.rules.models import EditorValue
 from mex.editor.search.state import SearchState
+from mex.editor.state import State
 
 
 def render_identifier(value: EditorValue) -> rx.Component:
@@ -14,9 +15,10 @@ def render_identifier(value: EditorValue) -> rx.Component:
                 value.text,
                 "Loading ...",
             ),
-            href=f"{value.href}",
+            on_click=State.navigate(value.href),
             high_contrast=True,
             role="link",
+            custom_attrs={"data-href": value.href},
         ),
         loading=rx.cond(
             value.text,

--- a/mex/editor/create/main.py
+++ b/mex/editor/create/main.py
@@ -5,7 +5,6 @@ from mex.editor.layout import page
 from mex.editor.rules.main import (
     editor_primary_source_stack,
     field_name,
-    page_leave_js,
     rule_page_header,
     validation_errors,
 )
@@ -73,7 +72,6 @@ def index() -> rx.Component:
                 editor_field,
             ),
             validation_errors(),
-            page_leave_js(),
             style={
                 "width": "100%",
                 "marginTop": "calc(2 * var(--space-6))",

--- a/mex/editor/edit/main.py
+++ b/mex/editor/edit/main.py
@@ -5,7 +5,6 @@ from mex.editor.edit.state import EditState
 from mex.editor.layout import page
 from mex.editor.rules.main import (
     editor_field,
-    page_leave_js,
     rule_page_header,
     validation_errors,
 )
@@ -60,7 +59,6 @@ def index() -> rx.Component:
                 editor_field,
             ),
             validation_errors(),
-            page_leave_js(),
             style={
                 "width": "100%",
                 "marginTop": "calc(2 * var(--space-6))",

--- a/mex/editor/edit/state.py
+++ b/mex/editor/edit/state.py
@@ -4,6 +4,7 @@ import reflex as rx
 from reflex.event import EventSpec
 
 from mex.editor.rules.state import RuleState
+from mex.editor.state import State
 
 
 class EditState(RuleState):
@@ -32,10 +33,11 @@ class EditState(RuleState):
             for ps in field.primary_sources
         )
 
-    def disable_all_primary_source_and_editor_values(self) -> None:
+    def disable_all_primary_source_and_editor_values(self) -> EventSpec:
         """Disable all primary source and editor values."""
         for field in self.fields:
             for ps in field.primary_sources:
                 ps.enabled = False
                 for value in ps.editor_values:
                     value.enabled = False
+        return State.set_current_page_has_changes(True)

--- a/mex/editor/layout.py
+++ b/mex/editor/layout.py
@@ -44,9 +44,10 @@ def nav_link(item: NavItem) -> rx.Component:
     """Return a link component for the given navigation item."""
     return rx.link(
         rx.text(item.title, size="4", weight="medium"),
-        href=item.raw_path,
+        on_click=State.navigate(item.raw_path),
         underline=item.underline,
         class_name="nav-item",
+        custom_attrs={"data-href": item.raw_path},
     )
 
 
@@ -122,6 +123,51 @@ def nav_bar() -> rx.Component:
     )
 
 
+def navigate_away_dialog() -> rx.Component:
+    """Render a dialog that informs the user about unsaved changes on the page.
+
+    If the dialog is dismissed navigatio is stopped and the user stays on the page
+    ; otherwise navigate away.
+    """
+    return rx.alert_dialog.root(
+        rx.alert_dialog.content(
+            rx.alert_dialog.title("Unsaved changes"),
+            rx.alert_dialog.description(
+                "There are unsaved changes on the page. If u navigate away "
+                "these changes will be lost. Do you want to navigate anyway?",
+            ),
+            rx.flex(
+                rx.alert_dialog.cancel(
+                    rx.button("Cancel", on_click=State.close_navigate_dialog)
+                ),
+                rx.alert_dialog.action(
+                    rx.button(
+                        "Discard changes",
+                        color_scheme="red",
+                        on_click=[
+                            State.close_navigate_dialog,
+                            State.set_current_page_has_changes(False),
+                            State.navigate(State.navigate_target),
+                        ],
+                    )
+                ),
+                spacing="3",
+            ),
+        ),
+        open=State.navigate_dialog_open,
+    )
+
+
+def page_leave_js() -> rx.Component:
+    """Render page leave java script import.
+
+    Returns:
+        rx.Component: The script component refrencing the
+        '/page-leave-warn-unsaved-changes.js'
+    """
+    return rx.script(src="/page-leave-warn-unsaved-changes.js")
+
+
 def page(*children: rx.Component) -> rx.Component:
     """Return a page fragment with navigation bar and given children."""
     return rx.cond(
@@ -138,6 +184,8 @@ def page(*children: rx.Component) -> rx.Component:
                 },
                 custom_attrs={"data-testid": "page-body"},
             ),
+            navigate_away_dialog(),
+            page_leave_js(),
             style={
                 "--app-max-width": "calc(1480px * var(--scaling))",
                 "--app-min-width": "calc(800px * var(--scaling))",

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -584,13 +584,3 @@ def rule_page_header(title: rx.Component) -> rx.Component:
             "zIndex": "999",
         },
     )
-
-
-def page_leave_js() -> rx.Component:
-    """Render page leave java script import.
-
-    Returns:
-        rx.Component: The script component refrencing the
-        '/page-leave-warn-unsaved-changes.js'
-    """
-    return rx.script(src="/page-leave-warn-unsaved-changes.js")

--- a/mex/editor/rules/state.py
+++ b/mex/editor/rules/state.py
@@ -210,11 +210,13 @@ class RuleState(State):
         field_name: str,
         href: str | None,
         enabled: bool,  # noqa: FBT001
-    ) -> None:
+    ) -> EventSpec | None:
         """Toggle the `enabled` flag of a primary source."""
         for primary_source in self._get_primary_sources_by_field_name(field_name):
             if primary_source.name.href == href:
                 primary_source.enabled = enabled
+                return State.set_current_page_has_changes(True)
+        return None
 
     @rx.event
     def toggle_field_value(
@@ -222,12 +224,15 @@ class RuleState(State):
         field_name: str,
         value: EditorValue,
         enabled: bool,  # noqa: FBT001
-    ) -> None:
+    ) -> EventSpec | None:
         """Toggle the `enabled` flag of a field value."""
         for primary_source in self._get_primary_sources_by_field_name(field_name):
             for editor_value in primary_source.editor_values:
                 if editor_value == value:
                     editor_value.enabled = enabled
+                    return State.set_current_page_has_changes(True)
+
+        return None
 
     @rx.event
     def toggle_field_value_editing(

--- a/mex/editor/rules/state.py
+++ b/mex/editor/rules/state.py
@@ -36,7 +36,6 @@ class RuleState(State):
     fields: list[EditorField] = []
     stem_type: str | None = None
     validation_messages: list[ValidationMessage] = []
-    has_changes: bool = False
 
     @rx.event(background=True)
     async def resolve_identifiers(self) -> None:
@@ -144,7 +143,7 @@ class RuleState(State):
             )
             return
 
-        yield self.set_has_changes(False)
+        yield State.set_current_page_has_changes(False)
         # clear cache to show edits in the UI
         resolve_identifier.cache_clear()
         # trigger redirect to edit page or refresh state
@@ -228,42 +227,26 @@ class RuleState(State):
             index
         ].being_edited = not primary_source.editor_values[index].being_edited
 
-    def update_has_changes(self) -> EventSpec:
-        """Update the has changes value on client side."""
-        return rx.call_script(
-            f"window.updateMexEditorChanges({str(self.has_changes).lower()})",
-        )
-
-    @rx.event
-    def set_has_changes(self, value: bool) -> EventSpec:  # noqa: FBT001
-        """Set the has changes attribute to the given value.
-
-        Args:
-            value (bool): The value of the has changes attribute.
-        """
-        self.has_changes = value
-        return self.update_has_changes()
-
     @rx.event
     def add_additive_value(self, field_name: str) -> EventSpec:
         """Add an additive rule to the given field."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values.append(EditorValue(being_edited=True))
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)
 
     @rx.event
     def remove_additive_value(self, field_name: str, index: int) -> EventSpec:
         """Remove an additive rule from the given field."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values.pop(index)
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)
 
     @rx.event
     def set_text_value(self, field_name: str, index: int, value: str) -> EventSpec:
         """Set the text attribute on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].text = value
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)
 
     @rx.event
     def set_identifier_value(
@@ -273,14 +256,14 @@ class RuleState(State):
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].identifier = value
         primary_source.editor_values[index].href = f"/item/{value}"
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)
 
     @rx.event
     def set_badge_value(self, field_name: str, index: int, value: str) -> EventSpec:
         """Set the badge attribute on an additive editor value."""
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].badge = value
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)
 
     @rx.event
     def set_href_value(self, field_name: str, index: int, value: str) -> EventSpec:
@@ -288,4 +271,4 @@ class RuleState(State):
         primary_source = self._get_editable_primary_source_by_field_name(field_name)
         primary_source.editor_values[index].href = value
         primary_source.editor_values[index].external = True
-        return self.set_has_changes(True)
+        return State.set_current_page_has_changes(True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ cruft==2.16.0
 mex-release==0.3.4
 pdm==2.25.9
 pre-commit==4.3.0
-
-reflex==0.6.8.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ cruft==2.16.0
 mex-release==0.3.4
 pdm==2.25.9
 pre-commit==4.3.0
+
+reflex==0.6.8.post1

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -88,7 +88,7 @@ def test_edit_page_renders_primary_sources(
     expect(primary_source).to_contain_text(had_primary_source.title[0].value)
     link = primary_source.get_by_role("link")
     expect(link).to_have_attribute(
-        "href", f"/item/{extracted_activity.hadPrimarySource}/"
+        "data-href", f"/item/{extracted_activity.hadPrimarySource}"
     )
 
 
@@ -174,8 +174,8 @@ def test_edit_page_resolves_identifier(
         extracted_organizational_unit.shortName[0].value
     )  # resolved short name of unit
     expect(link).to_have_attribute(
-        "href",
-        f"/item/{extracted_activity.contact[1]}/",  # link href
+        "data-href",
+        f"/item/{extracted_activity.contact[1]}",  # link href
     )
     expect(link).not_to_have_attribute("target", "_blank")  # internal link
 
@@ -373,8 +373,8 @@ def test_edit_page_resolves_additive_identifier(
     )
     expect(rendered_identifier).to_have_count(1)
     assert (
-        rendered_identifier.first.get_attribute("href")
-        == f"/item/{organizational_unit.stableTargetId}/"
+        rendered_identifier.first.get_attribute("data-href")
+        == f"/item/{organizational_unit.stableTargetId}"
     )
 
     # assert raw identifier value is retained

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -144,7 +144,9 @@ def test_infobox_visibility_and_content(ingest_page: Page) -> None:
 
     for provider in ALL_AUX_PROVIDERS:
         tab = page.get_by_role("tab", name=provider)
-        tab.click()
+        tab.click(
+            timeout=50000
+        )  # high timeout cuz tab might be disabled due to loading
 
         tab_content = page.locator(f"[id*='{provider}'][role='tabpanel']")
         callout = tab_content.locator(".rt-CalloutRoot")


### PR DESCRIPTION
### PR Context
Merged this feature with the existing browser-tab/-window warn feature (https://github.com/robert-koch-institut/mex-editor/tree/feature/mx-1979-Unsaved-changes-between-reflex-pages)

### Added
- Warning when a page reflex navigates and there are still changes on the current page

### Changes
- Existing feature about warning when browser tab or window is closed

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
