### PR TITLE
Bump cookiecutter template to dd987e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "af9ddce126397e3b56a29be097449b22199dcecd",
+  "commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb",
   "context": {
     "cookiecutter": {
       "project_name": "editor",
       "short_summary": "The editor enables anyone to create and edit entities in a simple and fast way.",
       "long_summary": "The editor is a web application for the MEx metadata catalog built with a FastAPI backend and an Angular frontend. It provides a user-friendly interface for creating, editing and managing metadata entities, making research data at RKI findable, accessible and reusable.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "af9ddce126397e3b56a29be097449b22199dcecd"
+      "_commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb"
     }
   },
   "directory": null,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         name: ruff-check
@@ -30,7 +30,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.7
+    rev: 0.11.8
     hooks:
       - id: uv-lock
         name: uv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
+
 ### Deprecated
 
 ### Removed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.7
-pre-commit==4.5.1
+uv==0.11.8
+pre-commit==4.6.0


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
