### PR TITLE
Bump cookiecutter template to 52887e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "1d816db77df20388022165cab12f45821d0b9f6d",
+  "commit": "52887e07dbc2501edea124e2a27a4f472f970d7e",
   "context": {
     "cookiecutter": {
       "project_name": "editor",
       "short_summary": "The editor enables anyone to create and edit entities in a simple and fast way.",
       "long_summary": "The editor is a web application for the MEx metadata catalog built with a FastAPI backend and an Angular frontend. It provides a user-friendly interface for creating, editing and managing metadata entities, making research data at RKI findable, accessible and reusable.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "1d816db77df20388022165cab12f45821d0b9f6d"
+      "_commit": "52887e07dbc2501edea124e2a27a4f472f970d7e"
     }
   },
   "directory": null,

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: 3.14
 
       - name: Setup pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Install requirements
         run: make install
@@ -64,7 +64,7 @@ jobs:
         run: make docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./docs/dist
 
@@ -81,4 +81,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.8
+    rev: 0.11.20
     hooks:
       - id: uv-lock
         name: uv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/52887e
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
 - renovate: group non-major npm updates into a single PR


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/52887e

### Conflicts

```diff
diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
@@ -9,7 +9,7 @@ repos:
       - id: ruff-format
         name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: pretty-format-json
         name: json
```
