### PR TITLE
hotfix/remove-npm-args-from-nodeenv-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- npm version is read from package.json during nodeenv installation
 - Initial Layout with header (including theme switcher and language switcher with noop) and footer
 - vitest/ui for better dev experience
 
 ### Changes
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/11612b
-
 - update node to 24.15.0
 - updated angular to 21.2.17
-- updated template to https://github.com/robert-koch-institut/mex-template/commit/52887e
 - renovate: group non-major npm updates into a single PR
 
 ### Deprecated

--- a/mex/editor/frontend.py
+++ b/mex/editor/frontend.py
@@ -129,21 +129,7 @@ def read_npm_version_from_package_json() -> str | None:
 
 def install() -> None:
     """Install nodeenv and npm dependencies."""
-    npm_version = read_npm_version_from_package_json()
-    if not npm_version:
-        msg = "Unable to install nodeenv without npm_version. Ensure 'packageManager'"
-        "exists in 'package.json'."
-        raise ValueError(msg)
-    exec_py(
-        [
-            "nodeenv",
-            f"{NODE_VIRTUAL_ENV}",
-            "--force",
-            "--npm",
-            npm_version,
-            "--with-npm",
-        ]
-    )
+    exec_py(["nodeenv", f"{NODE_VIRTUAL_ENV}", "--force"])
     exec_npm(["clean-install"])
 
 


### PR DESCRIPTION
### PR Context
Reverts the explicit npm installation during nodeenv install

### Removed
- `--npm` args from nodeenv install