### PR TITLE
Bump cookiecutter template to 1.2.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
-  "checkout": null,
-  "commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff",
+  "checkout": "1.2.0",
+  "commit": "48ce427bbd5a3ff53c603e6cea58c74de439ecc5",
   "context": {
     "cookiecutter": {
       "project_name": "editor",
       "short_summary": "The editor enables anyone to create and edit entities in a simple and fast way.",
       "long_summary": "The editor is a web application for the MEx metadata catalog built with a FastAPI backend and an Angular frontend. It provides a user-friendly interface for creating, editing and managing metadata entities, making research data at RKI findable, accessible and reusable.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff"
+      "_commit": "48ce427bbd5a3ff53c603e6cea58c74de439ecc5"
     }
   },
   "directory": null,

--- a/.dockerignore
+++ b/.dockerignore
@@ -113,19 +113,6 @@ dmypy.json
 .history/
 *.code-workspace
 
-# Node and Angular
-.angular/
-.nodeenv
-.sass-cache/
-connect.lock
-coverage
-libpeerconnection.log
-node_modules
-npm-debug.log
-out-tsc
-testem.log
-typings
-
 # SQLite databases
 *.db
 

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -65,25 +65,24 @@ jobs:
       - name: Update template and commit
         id: update
         run: |
-          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
-          template_tag=$(git ls-remote --tags --sort=-v:refname "${template_url}" | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')
-          if cruft check --checkout "${template_tag}"; then
+          if cruft check; then
             echo template is up to date
             exit 0
           fi
-          if [[ -n "$(gh pr list --label cruft --state open --json number --jq '.[].number')" ]]; then
+          if [[ $(gh pr list --label cruft | wc -c) -ne 0 ]]; then
             echo already seeing pull request
             exit 0
           fi
-          echo "template_tag=${template_tag}" >> "$GITHUB_OUTPUT"
+          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
+          template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
+          echo "template_ref=${template_ref}" >> "$GITHUB_OUTPUT"
           git checkout main
-          git checkout -b cruft/mex-template-${template_tag}
-          cruft update --checkout "${template_tag}" --skip-apply-ask
-          printf '### Changes\n\n- new template %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
-          sed -i "0,/^### Changes$/{/^### Changes$/{N;s|\n|\n\n- new template ${template_url}/releases/tag/${template_tag}|}}" CHANGELOG.md
+          git checkout -b cruft/cookiecutter-template-${template_ref}
+          cruft update --skip-apply-ask
+          printf '### Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
+          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
-            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           fi
           find . -type f -name "*.rej" | while read -r line ; do
             printf '\n```diff\n' >> .cruft-pr-body
@@ -91,31 +90,25 @@ jobs:
             printf '```\n' >> .cruft-pr-body
           done
           git add --all --verbose
-          git commit --message "Update mex-template to $template_tag" --verbose
+          git commit --message "Bump cookiecutter template to $template_ref" --verbose
 
       - name: Push branch
-        if: steps.update.outputs.template_tag
+        if: steps.update.outputs.template_ref
         env:
-          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_tag: ${{ steps.update.outputs.template_tag }}
+          GH_TOKEN: ${{ secrets.MEX_CONTENT_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --set-upstream origin cruft/mex-template-${template_tag} --force --verbose
+          git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
 
       - name: Create pull request
-        if: steps.update.outputs.template_tag
+        if: steps.update.outputs.template_ref
         env:
-          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_tag: ${{ steps.update.outputs.template_tag }}
-          has_conflicts: ${{ steps.update.outputs.has_conflicts }}
+          GH_TOKEN: ${{ secrets.MEX_COLLAB_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
         run: |
-          draft_flag=""
-          if [[ "${has_conflicts}" == "true" ]]; then
-            draft_flag="--draft"
-          fi
           gh pr create \
-          --title "Bump cookiecutter template to ${template_tag}" \
+          --title "Bump cookiecutter template to ${template_ref}" \
           --body-file .cruft-pr-body \
           --label cruft \
-          --assignee ${MEX_BOT_USER} \
-          ${draft_flag}
+          --assignee ${MEX_BOT_USER}

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -42,7 +42,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -40,7 +40,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
@@ -55,7 +55,7 @@ jobs:
           python-version: 3.14
 
       - name: Setup pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Install requirements
         run: make install
@@ -64,7 +64,7 @@ jobs:
         run: make docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./docs/dist
 
@@ -81,4 +81,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -46,7 +46,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -88,7 +88,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write  # Required for cosign signing
 
     steps:
       - name: Checkout repo
@@ -106,29 +105,15 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build, tag and push docker image
-        id: push_step
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v.7.1.0
         env:
           IMAGE: ghcr.io/${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
-        with:
-          push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.sha }}
-            ${{ env.IMAGE }}:${{ env.TAG }}
-          outputs: type=image,oci-mediatypes=true
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: 'v2.4.1'
-
-      - name: Sign Docker image keyless
-        env:
-          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push_step.outputs.digest }}
         run: |
-          cosign sign --yes "$IMAGE"
+          docker build . \
+          --tag ${IMAGE}:latest \
+          --tag ${IMAGE}:${{ github.sha }} \
+          --tag ${IMAGE}:${TAG}
+          docker push --all-tags ${IMAGE}
 
   distribute:
     runs-on: ubuntu-latest
@@ -146,7 +131,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -167,6 +152,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv build --out-dir dist
           gh release create ${{ needs.release.outputs.tag }} \
-          --generate-notes --latest --verify-tag dist/*
+          --generate-notes --latest --verify-tag
+          uv build --out-dir dist
+          for filename in dist/*; do
+            gh release upload ${{ needs.release.outputs.tag }} ${filename};
+          done

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -46,7 +46,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ downloads/
 eggs/
 lib/
 lib64/
+locked-requirements.txt
 MANIFEST
 parts/
 sdist/
@@ -111,25 +112,8 @@ dmypy.json
 
 # VisualStudioCode
 .vscode/*
-!.vscode/extensions.json
-!.vscode/launch.json
-!.vscode/settings.json
-!.vscode/tasks.json
 .history/
 *.code-workspace
-
-# Node and Angular
-.angular/
-.nodeenv
-.sass-cache/
-connect.lock
-coverage
-libpeerconnection.log
-node_modules
-npm-debug.log
-out-tsc
-testem.log
-typings
 
 # SQLite databases
 *.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     - id: mypy
       name: mypy
       entry: uv run dmypy run --timeout 7200 -- mex tests
-      files: ^(mex|tests)/|pyproject\.toml$
+      files: ^(mex|tests)/
       language: system
       pass_filenames: false
       types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.2.0
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/0d8c47
 
 - alot of manual package updates to help renovatebot

--- a/README.md
+++ b/README.md
@@ -114,13 +114,6 @@ If u're using VSCode u can use the predefined launch configuration.
 - run directly using docker `make run`
 - start with docker compose `make start`
 
-### Container verification
-
-Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
-
-To verify an image manually:
-`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-editor/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-editor:<tag>`
-
 ## Commands
 
 - run `uv run {command} --help` to print instructions

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "on monday"
+            "before 4am on monday"
         ]
     },
     "packageRules": [


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.2.0

### Conflicts

```diff
diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.3.3
-uv==0.11.15
-pre-commit==4.6.0
+mex-release==1.3.0
+uv==0.10.12
+pre-commit==4.5.1
```

```diff
diff a/Dockerfile b/Dockerfile	(rejected hunks)
@@ -1,20 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14 AS builder
-
-WORKDIR /build
-
-ENV PIP_DISABLE_PIP_VERSION_CHECK=on
-ENV PIP_NO_INPUT=on
-ENV PIP_PREFER_BINARY=on
-ENV PIP_PROGRESS_BAR=off
-
-COPY . .
-
-RUN pip install --no-cache-dir -r requirements.txt
-RUN uv export --no-dev --no-editable | uv pip install --system --no-deps -r -
-
-FROM python:3.14-slim
+FROM python:3.14 AS base
 
 LABEL org.opencontainers.image.authors="mex@rki.de"
 LABEL org.opencontainers.image.description="The editor enables anyone to create and edit entities in a simple and fast way."
@@ -25,14 +11,28 @@ LABEL org.opencontainers.image.vendor="robert-koch-institut"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONOPTIMIZE=1
 
+ENV PIP_DISABLE_PIP_VERSION_CHECK=on
+ENV PIP_NO_INPUT=on
+ENV PIP_PREFER_BINARY=on
+ENV PIP_PROGRESS_BAR=off
+
 ENV MEX_EDITOR_HOST=0.0.0.0
 
 WORKDIR /app
 
-COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
-COPY --from=builder /usr/local/bin/editor /usr/local/bin/editor
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "10001" \
+    mex
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r locked-requirements.txt --no-deps
 
-USER 10001
+USER mex
 
 EXPOSE 8080
 
```

```diff
diff a/compose.yaml b/compose.yaml	(rejected hunks)
@@ -3,9 +3,12 @@ services:
     build:
       context: .
     ports:
-      - 8080:8080
+      - 8081:8081
     environment:
       - MEX_EDITOR_HOST=0.0.0.0
+      - MEX_EDITOR_PORT=8080
+    expose:
+      - 8081
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/_system/check" ]
       interval: 60s
```

```diff
diff a/README.md b/README.md	(rejected hunks)
@@ -6,7 +6,7 @@ The editor enables anyone to create and edit entities in a simple and fast way.
 [![cve-scan](https://github.com/robert-koch-institut/mex-editor/actions/workflows/cve-scan.yml/badge.svg)](https://github.com/robert-koch-institut/mex-editor/actions/workflows/cve-scan.yml)
 [![documentation](https://github.com/robert-koch-institut/mex-editor/actions/workflows/documentation.yml/badge.svg)](https://robert-koch-institut.github.io/mex-editor)
 [![linting](https://github.com/robert-koch-institut/mex-editor/actions/workflows/linting.yml/badge.svg)](https://github.com/robert-koch-institut/mex-editor/actions/workflows/linting.yml)
-[![opencode](https://github.com/robert-koch-institut/mex-editor/actions/workflows/opencode.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-editor)
+[![open-code](https://github.com/robert-koch-institut/mex-editor/actions/workflows/open-code.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-editor)
 [![testing](https://github.com/robert-koch-institut/mex-editor/actions/workflows/testing.yml/badge.svg)](https://github.com/robert-koch-institut/mex-editor/actions/workflows/testing.yml)
 
 ## Project
```

```diff
diff a/Makefile b/Makefile	(rejected hunks)
@@ -43,6 +43,7 @@ wheel:
 image:
 	# build the docker image
 	@ echo building docker image mex-editor:${LATEST}; \
+	export DOCKER_BUILDKIT=1; \
 	docker build \
 		--tag rki/mex-editor:${LATEST} \
 		--tag rki/mex-editor:latest .; \
@@ -52,13 +53,15 @@ run: image
 	@ echo running docker container mex-editor:${LATEST}; \
 	docker run \
 		--env MEX_EDITOR_HOST=0.0.0.0 \
-		--publish 8080:8080 \
+		--publish 8081:8081 \
 		rki/mex-editor:${LATEST}; \
 
-start:
+start: image
 	# start the service using docker compose
 	@ echo start mex-editor:${LATEST} with compose; \
-	docker compose up --build --remove-orphans; \
+	export DOCKER_BUILDKIT=1; \
+	export COMPOSE_DOCKER_CLI_BUILD=1; \
+	docker compose up --remove-orphans; \
 
 docs:
 	# use sphinx to auto-generate html docs from code
```

```diff
diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
@@ -1,15 +1,13 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.4
     hooks:
       - id: ruff-check
-        name: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: v5.0.0
     hooks:
       - id: pretty-format-json
         name: json
@@ -25,7 +23,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.20
+    rev: 0.10.7
     hooks:
       - id: uv-lock
         name: uv
```

```diff
diff a/renovate.json b/renovate.json	(rejected hunks)
@@ -38,40 +38,15 @@
             "pinDigests": true
         },
         {
-            "description": "Group all GitHub Actions updates into a single PR",
-            "groupName": "github-actions",
-            "matchManagers": [
-                "github-actions"
-            ]
-        },
-        {
-            "description": "Group all non-major Python updates into a single PR",
-            "groupName": "python non-major",
-            "matchCurrentVersion": "!/^0/",
-            "matchManagers": [
-                "pep621",
-                "pip_requirements"
-            ],
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "pin",
-                "digest"
-            ]
-        },
-        {
-            "description": "Immediately apply updates of mex packages in dedicated PR",
-            "groupName": null,
+            "description": "Immediately apply updates of mex packages",
             "matchPackageNames": [
                 "mex-*"
             ],
             "minimumReleaseAge": "0 days"
         }
     ],
+    "platformCommit": "enabled",
     "prFooter": "",
-    "pre-commit": {
-        "enabled": true
-    },
     "vulnerabilityAlerts": {
         "enabled": true
     }
```

```diff
diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "The editor enables anyone to create and edit entities in a simple and fast way."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }
-license = "MIT"
+license = { file = "LICENSE" }
 urls = { Repository = "https://github.com/robert-koch-institut/mex-editor" }
 requires-python = ">=3.14,<3.15"
 dependencies = [
```

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -95,6 +94,28 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
+      - name: Cache requirements
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        env:
+          cache-name: cache-requirements
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.14
+
+      - name: Install requirements
+        run: make setup
+
+      - name: Generate locked requirements.txt
+        run: |
+          uv export --no-dev --output locked-requirements.txt --no-hashes
+
       - name: Login to container registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
```

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -59,6 +59,11 @@ jobs:
       - name: Install requirements
         run: make setup
 
+      - name: Export dependencies
+        run: |
+          mkdir --parents uv
+          uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
+
       - name: Run trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
```

```diff
diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -27,7 +27,6 @@ jobs:
       - name: Run renovatebot
         uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
         env:
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.MEX_PLAIN_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
           configurationFile: renovate.json
```
